### PR TITLE
Update Proxy.java - When teleporting into unloaded chunk

### DIFF
--- a/src/main/java/com/panicnot42/warpbook/Proxy.java
+++ b/src/main/java/com/panicnot42/warpbook/Proxy.java
@@ -61,6 +61,13 @@ public class Proxy
     NetworkRegistry.TargetPoint oldPoint = new NetworkRegistry.TargetPoint(player.dimension, player.posX, player.posY, player.posZ, 64);
     NetworkRegistry.TargetPoint newPoint = new NetworkRegistry.TargetPoint(wp.dim, wp.x, wp.y, wp.z, 64);
     player.addExhaustion(calculateExhaustion(player.getEntityWorld().difficultySetting, WarpBookMod.exhaustionCoefficient, crossDim));
+    
+    net.minecraft.world.Chunk chunk = player.worldObj.getChunkFromBlockCoords(wp.x, wp.z); // get the chunk from x and z coords
+    if (!chunk.isChunkLoaded()) // will only run if that chunk is not already loaded
+    {
+      player.worldObj.getChunkProvider().loadChunk(chunk.xPosition, chunk.zPosition); // load the destination chunk
+    }
+    
     if (crossDim && !player.worldObj.isRemote) transferPlayerToDimension((EntityPlayerMP)player, wp.dim, ((EntityPlayerMP)player).mcServer.getConfigurationManager());
     player.setPositionAndUpdate(wp.x - 0.5f, wp.y + 0.5f, wp.z - 0.5f);
     if (!player.worldObj.isRemote)


### PR DESCRIPTION
Occasionally, when teleporting about, I will teleport into an unloaded chunk (or what I assume is an unloaded chunk) and I must re log into the world to loaded it up.
What makes me think this is an unloaded chunk, is that when I teleport, nothing is loaded around me. All I can see is the horizon, and I am unable to move (moving the mouse puts the screen back at the rotation it was before moving)

This PR SHOULD fix that issue. Hopefully it is valid for your liking. :)

Changelog:
   Makes sure the the destination chunk is loaded before teleporting
